### PR TITLE
Fix adding link tag to head when word 'body' is present in content

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ HtmlWebpackPugPlugin.prototype.injectAssetsIntoSlim = function (file, styles, sc
  */
 HtmlWebpackPugPlugin.prototype.injectAssets = function (file, head, body, assets) {
   var self = this;
-  var bodyRegExp = /( *)(%?body)/i;
+  var bodyRegExp = /^( *)(%?body)\b/im;
 
   var match = bodyRegExp.exec(file);
   if (match) {


### PR DESCRIPTION
This fixes issue #7 and hopefully doesn't break anything else.