### PR TITLE
fix for spacing in style and script inject

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,7 +332,7 @@ HtmlWebpackPugPlugin.prototype.injectAssets = function (html, head, body, assets
   var match = regExp.exec(html);
   if (match) {
     var headSpace = match[1];
-    var hlSpace = headSpace.repeat(2);
+    var hlSpace = headSpace + "  ";
     if (head.length) {
       head = head.map(function(v) {
         return hlSpace + v;


### PR DESCRIPTION
The hlSpace is not double head space under every circumstance. The problem for me was that i have a structure

```
if abc
  body
    head
```

Double the head space is indenting the links to far. Changing that indentation to double quotes is fixing the issue for me.