### PR TITLE
Added support for Webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,15 +9,16 @@ function HtmlWebpackPugPlugin (options) {
 HtmlWebpackPugPlugin.prototype.apply = function (compiler) {
   var self = this;
   // Hook into the html-webpack-plugin processing
-  compiler.plugin('compilation', function (compilation) {
-    compilation.plugin('html-webpack-plugin-before-html-processing', function (htmlPluginData, callback) {
+  compiler.hooks.compilation.tap('compilation', function (compilation) {
+    compilation.hooks.htmlWebpackPluginBeforeHtmlProcessing.tapAsync('html-webpack-plugin-before-html-processing', function (htmlPluginData, callback) {
       self.preProcessHtml(htmlPluginData, callback);
     });
-    compilation.plugin('html-webpack-plugin-after-html-processing', function (htmlPluginData, callback) {
+    compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync('html-webpack-plugin-after-html-processing', function (htmlPluginData, callback) {
       self.postProcessHtml(htmlPluginData, callback);
     });
   });
 };
+
 
 /**
  * Is it no longer supported


### PR DESCRIPTION
The current library throws an issue when attempting to run on the Webpack 4, which was just released (related issue [here](https://github.com/negibouze/html-webpack-pug-plugin/issues/15)), so this PR introduces a fix for it using the new plugins API. 

Everything should be in order, as the plugin seems to work now for WP4, but I'm not super familiar with the new API so let me know if I overlooked anything.

Thanks.